### PR TITLE
Fix issue in mcp-app deployment

### DIFF
--- a/production/manifests/mcp-app/deployment.yaml
+++ b/production/manifests/mcp-app/deployment.yaml
@@ -16,7 +16,9 @@ spec:
     spec:
       containers:
       - name: mcp-app
-        image: nginx:missing
+        image: nginx:1.21
+        ports:
+        - containerPort: 80
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This PR fixes the invalid nginx image tag from 'missing' to '1.21' in the mcp-app deployment manifest.

Changes:
- Updated nginx image from nginx:missing to nginx:1.21
- Added containerPort specification for better clarity

This should resolve the deployment sync issues in ArgoCD.